### PR TITLE
Add Python 3 support

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from build_utils import compile_a_file_collection, Link
 import optparse
 import collections
@@ -223,7 +224,7 @@ def availableCalculators():
             produced_file = open(".products","r")
             for produced_file_line in produced_file:
                 os.system("rm "+produced_file_line)
-                print "rm "+produced_file_line[:-1]
+                print("rm "+produced_file_line[:-1])
             produced_file.close()
             # Clear the products file itself
             os.system("rm .products")

--- a/build_utils.py
+++ b/build_utils.py
@@ -101,11 +101,11 @@ def compile_a_file_collection(base_dir, file_collection, compiler, options, incl
             modif_data = os.path.getmtime(file_name)
             # Then open the dic with last mod. dates
             if os.path.exists(modif_file):
-                last_modif_data = pickle.load(open(modif_file,"r"))
+                last_modif_data = pickle.load(open(modif_file,"rb"))
             else:
                 last_modif_data = -1 # If it does not exist, compile
             # Finally, do last = current for the next step
-            pickle.dump(modif_data, open(modif_file,"w"))
+            pickle.dump(modif_data, open(modif_file,"wb"))
             
             filewoext,extension = file_name.split(".") #@UnusedVariable
             product = os.path.join(folder,filewoext)+product_extension

--- a/pyRMSD/RMSDCalculator.py
+++ b/pyRMSD/RMSDCalculator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy
 import pyRMSD.calculators
 from pyRMSD.availableCalculators import availableCalculators
@@ -46,7 +47,7 @@ class RMSDCalculator(object):
         @date: 26/11/2012
         """
         if not calculatorType in availableCalculators():
-            print "Calculator ", calculatorType, " is not an available calculator."
+            print("Calculator ", calculatorType, " is not an available calculator.")
             raise ValueError
         else:
             self.fitting_coordinates = fittingCoordsets
@@ -58,7 +59,7 @@ class RMSDCalculator(object):
             if self.calculation_coordinates is not None:
                 self.calculation_coordinates = calculationCoordsets
                 if self.number_of_conformations != self.calculation_coordinates.shape[0]:
-                    print "Calculation coordinates must hold the same number of conformations than fitting coordinates."
+                    print("Calculation coordinates must hold the same number of conformations than fitting coordinates.")
                     raise ValueError
                 self.number_of_calculation_atoms = self.calculation_coordinates.shape[1]
             else:

--- a/pyRMSD/benchmark/BenchmarkCheckBetterOMPAndCUDAParams.py
+++ b/pyRMSD/benchmark/BenchmarkCheckBetterOMPAndCUDAParams.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import os
@@ -13,26 +14,26 @@ if __name__ == '__main__':
     using_cuda = "QCP_CUDA_CALCULATOR" in pyRMSD.RMSDCalculator.availableCalculators()
     
     if not using_cuda:
-        print "Build it using --cuda."
+        print("Build it using --cuda.")
         exit()
         
     ######################
     # BENCHMARKING
     ######################
     # Reading coords
-    print "Loading file..."
+    print("Loading file...")
     t1 = time.time()
-    print "\tUncompressing..."
+    print("\tUncompressing...")
     open("tmp_amber_long.pdb","w").write(bz2.BZ2File("data/amber_long.pdb.tar.bz2").read())
-    print "\tLoading..."
+    print("\tLoading...")
     reader = Reader().readThisFile('tmp_amber_long.pdb').gettingOnlyCAs()
     coordsets = reader.read() 
     number_of_atoms = reader.numberOfAtoms
     number_of_conformations = reader.numberOfFrames
     os.system("rm tmp_amber_long.pdb")
-    print "\tDeleting temporary file"
+    print("\tDeleting temporary file")
     t2 = time.time()
-    print 'Loading took %0.3f s' % (t2-t1)
+    print('Loading took %0.3f s' % (t2-t1))
     
     for number_of_threads in range(1,13):
         calculator = pyRMSD.RMSDCalculator.RMSDCalculator(calculatorType="QCP_OMP_CALCULATOR", 
@@ -42,7 +43,7 @@ if __name__ == '__main__':
         rmsd = calculator.pairwiseRMSDMatrix()
         t2 = time.time()
         del rmsd
-        print 'OpenMP calculation took %0.3fs with number of threads %d' % (t2-t1, number_of_threads)
+        print('OpenMP calculation took %0.3fs with number of threads %d' % (t2-t1, number_of_threads))
          
     # Generate test parameters
     max_n_threads = 512
@@ -68,7 +69,7 @@ if __name__ == '__main__':
             rmsd = calculator.pairwiseRMSDMatrix()
             t2 = time.time()
             del rmsd
-            print 'Calculating took %0.3fs with CUDA and numthreads:%d and numblocks:%d' % (t2-t1, number_of_threads, number_of_blocks)
+            print('Calculating took %0.3fs with CUDA and numthreads:%d and numblocks:%d' % (t2-t1, number_of_threads, number_of_blocks))
 
         #Best in Minotauro (NVIDIA M2090): 128, 64
         #Best with Quadro FX 580: 2, 16

--- a/pyRMSD/benchmark/BenchmarkCondensedMatrix.py
+++ b/pyRMSD/benchmark/BenchmarkCondensedMatrix.py
@@ -3,6 +3,7 @@ Created on 07/08/2012
 
 @author: victor
 """
+from __future__ import print_function
 import time
 import random
 from pyRMSD.condensedMatrix import CondensedMatrix
@@ -11,7 +12,7 @@ import pyRMSD.benchmark.alias.CythonCondensedMatrix as CythonCondensedMatrixes #
 
 if __name__ == '__main__':
     
-    print "Creating data..."
+    print("Creating data...")
     row_size = 10000
     matrix_elem_size = row_size*(row_size-1)/2
     contents = random.sample(xrange(matrix_elem_size+1),matrix_elem_size)
@@ -21,9 +22,9 @@ if __name__ == '__main__':
     matrixes["CythonCondensedMatrix"] = CythonCondensedMatrixes.CythonCondensedMatrix(contents)
     matrixes["CythonCondensedMatrixWithDiagonal"] = CythonCondensedMatrixes.CythonCondensedMatrixWithDiagonal(contents)
     
-    print "========================"
-    print "Serial access Benchmark"
-    print "========================"
+    print("========================")
+    print("Serial access Benchmark")
+    print("========================")
     
     for matrix_type in matrixes:
         irange = range(row_size)
@@ -34,11 +35,11 @@ if __name__ == '__main__':
             for j in jrange:
                 data = matrixes[matrix_type][i,j]
         time_end = time.time()
-        print matrix_type+" access benchmark took %.3f s"%(time_end-time_start)
+        print(matrix_type+" access benchmark took %.3f s"%(time_end-time_start))
        
-    print "========================"
-    print "Random Access Benchmark"
-    print "========================"
+    print("========================")
+    print("Random Access Benchmark")
+    print("========================")
     random_i = range(row_size)
     random.shuffle(random_i)
     random_j = range(row_size)
@@ -50,4 +51,4 @@ if __name__ == '__main__':
             for j in random_j:
                 data =  matrixes[matrix_type][i,j]
         time_end = time.time()
-        print "Random access benchmark took %.3f s for %s"%(time_end-time_start, matrix_type)
+        print("Random access benchmark took %.3f s for %s"%(time_end-time_start, matrix_type))

--- a/pyRMSD/benchmark/BenchmarkCuda.py
+++ b/pyRMSD/benchmark/BenchmarkCuda.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import numpy
@@ -14,15 +15,15 @@ if __name__ == '__main__':
     using_cuda = "QCP_CUDA_CALCULATOR" in pyRMSD.RMSDCalculator.availableCalculators()
     
     if not using_cuda:
-        print "Build it using --cuda."
+        print("Build it using --cuda.")
         exit()
     
     files = ["amber_5k.pdb","amber_10k.pdb","amber_15k.pdb","amber_20k.pdb","amber_25k.pdb","amber_30k.pdb","amber_35k.pdb"]  
     for pdb_file in files:
-        print "Reading file data/"+pdb_file,"...",
+        print("Reading file data/"+pdb_file,"...", end=' ')
         sys.stdout.flush()
         coordsets = numpy.load("data/%s.npy"%pdb_file.split(".")[0])
-        print "OK"
+        print("OK")
         number_of_conformations = coordsets.shape[0]
         number_of_atoms = coordsets.shape[1]
         
@@ -38,8 +39,8 @@ if __name__ == '__main__':
             t2 = time.time()
             del rmsd
             times.append(t2-t1)
-            print t2-t1
+            print(t2-t1)
             sys.stdout.flush()
-        print "With CUDA and ",pdb_file, " it took: ",numpy.mean(times),"[", numpy.std(times), "]"
+        print("With CUDA and ",pdb_file, " it took: ",numpy.mean(times),"[", numpy.std(times), "]")
         sys.stdout.flush()
 

--- a/pyRMSD/benchmark/BenchmarkNeighborOperations.py
+++ b/pyRMSD/benchmark/BenchmarkNeighborOperations.py
@@ -3,6 +3,7 @@ Created on 10/08/2012
 
 @author: victor
 """
+from __future__ import print_function
 import time
 import random
 import numpy
@@ -13,7 +14,7 @@ from pyRMSD.benchmark.alias.neighbourOps import choose_node_with_higher_cardinal
  
 if __name__ == '__main__':
     
-    print "Creating data..."
+    print("Creating data...")
     row_size = 20000
     matrix_elem_size = row_size*(row_size-1)/2
     contents = numpy.array(random.sample(xrange(matrix_elem_size+1),matrix_elem_size))
@@ -23,57 +24,57 @@ if __name__ == '__main__':
     matrix2 = PythonCondensedMatrix.CondensedMatrix(float_contents)
     remaining_nodes = range(row_size)
 
-    print "======================================"
-    print "'get_neighbors_for_node' benchmark"
-    print "======================================"
+    print("======================================")
+    print("'get_neighbors_for_node' benchmark")
+    print("======================================")
     time_start = time.time()
     neighbors1 = matrix.get_neighbors_for_node(1,remaining_nodes, 0.5)
     time_end = time.time()
-    print "Fast Neighbor search for Fast matrix took %.3fs"%(time_end-time_start)
+    print("Fast Neighbor search for Fast matrix took %.3fs"%(time_end-time_start))
     
     time_start = time.time()
     neighbors2 = matrix2.get_neighbors_for_node(1,remaining_nodes, 0.5)
     time_end = time.time()
-    print "Slow Neighbor search for Slow matrix took %.3fs"%(time_end-time_start)
+    print("Slow Neighbor search for Slow matrix took %.3fs"%(time_end-time_start))
     
     time_start = time.time()
     neighbors3 = get_neighbors_for_node(matrix, 1,remaining_nodes, 0.5)
     time_end = time.time()
-    print "Slow Neighbor search for Fast matrix took %.3fs"%(time_end-time_start)
+    print("Slow Neighbor search for Fast matrix took %.3fs"%(time_end-time_start))
     
-    print "======================================"
-    print "'get_neighbors_for_node' validation"
-    print "======================================"
+    print("======================================")
+    print("'get_neighbors_for_node' validation")
+    print("======================================")
     try:
         numpy.testing.assert_array_equal(neighbors1,neighbors2)
         numpy.testing.assert_array_equal(neighbors1,neighbors3)
-        print "OK"
-    except Exception,message:
-        print message
-        print "KO"
+        print("OK")
+    except Exception as message:
+        print(message)
+        print("KO")
     
-    print "================================================"
-    print "'choose_node_with_higher_cardinality' benchmark"
-    print "================================================"
+    print("================================================")
+    print("'choose_node_with_higher_cardinality' benchmark")
+    print("================================================")
     time_start = time.time()
     neighbors1 = matrix.choose_node_with_higher_cardinality(remaining_nodes, 0.5)
     time_end = time.time()
-    print "Fast Neighbor cardinality for Fast matrix took %.3fs"%(time_end-time_start)
+    print("Fast Neighbor cardinality for Fast matrix took %.3fs"%(time_end-time_start))
     
     time_start = time.time()
     neighbors2 = matrix2.choose_node_with_higher_cardinality(remaining_nodes, 0.5)
     time_end = time.time()
-    print "Slow Neighbor cardinality for Slow matrix took %.3fs"%(time_end-time_start)
+    print("Slow Neighbor cardinality for Slow matrix took %.3fs"%(time_end-time_start))
     
     time_start = time.time()
     neighbors3 = choose_node_with_higher_cardinality(matrix,remaining_nodes, 0.5)
     time_end = time.time()
-    print "Slow Neighbor cardinality for Fast matrix took %.3fs"%(time_end-time_start)
+    print("Slow Neighbor cardinality for Fast matrix took %.3fs"%(time_end-time_start))
     
-    print "================================================"
-    print "'choose_node_with_higher_cardinality' validation"
-    print "================================================"
+    print("================================================")
+    print("'choose_node_with_higher_cardinality' validation")
+    print("================================================")
     if(neighbors1 == neighbors2 and neighbors2 == neighbors3):
-        print "OK"
+        print("OK")
     else:
-        print "KO"
+        print("KO")

--- a/pyRMSD/benchmark/BenchmarkOpenMP.py
+++ b/pyRMSD/benchmark/BenchmarkOpenMP.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import numpy
@@ -21,10 +22,10 @@ if __name__ == '__main__':
              ]  
 
     for pdb_file, tries in files:
-        print "Reading file ", "data/"+pdb_file,"...",
+        print("Reading file ", "data/"+pdb_file,"...", end=' ')
         sys.stdout.flush()
         coordsets = numpy.load("data/%s.npy"%(pdb_file.split(".")[0]))
-        print "OK"
+        print("OK")
         number_of_conformations = coordsets.shape[0]
         number_of_atoms = coordsets.shape[1]
         
@@ -38,6 +39,6 @@ if __name__ == '__main__':
             t2 = time.time()
             del rmsd
             times.append(t2-t1)
-        print "With OpenMP and",pdb_file, " it took: ",numpy.mean(times),"[", numpy.std(times), "]"
+        print("With OpenMP and",pdb_file, " it took: ",numpy.mean(times),"[", numpy.std(times), "]")
         sys.stdout.flush()
 

--- a/pyRMSD/benchmark/BenchmarkOpenMPScalability.py
+++ b/pyRMSD/benchmark/BenchmarkOpenMPScalability.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import numpy
@@ -13,7 +14,7 @@ if __name__ == '__main__':
     coordsets = numpy.load("data/amber_30k.npy")
     number_of_conformations = coordsets.shape[0]
     number_of_atoms = coordsets.shape[1]
-    print "Coordsets read"
+    print("Coordsets read")
     sys.stdout.flush()
     calculator_types = ["KABSCH_OMP_CALCULATOR","QTRFIT_OMP_CALCULATOR","QCP_OMP_CALCULATOR"]
     for calculator_type in calculator_types:
@@ -28,6 +29,6 @@ if __name__ == '__main__':
                 t2 = time.time()
                 del rmsd
                 times.append(t2-t1)
-            print calculator_type, num_threads, numpy.mean(times),"[", numpy.std(times), "]"
+            print(calculator_type, num_threads, numpy.mean(times),"[", numpy.std(times), "]")
             sys.stdout.flush()
 

--- a/pyRMSD/benchmark/BenchmarkPrecision.py
+++ b/pyRMSD/benchmark/BenchmarkPrecision.py
@@ -4,6 +4,7 @@ Created on 22/02/2013
 @author: victor
 """
 
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import numpy
 import math
@@ -38,10 +39,10 @@ if __name__ == '__main__':
     rms = {}
     calculator_names = rmsds.keys()
     for calculator_name_i in calculator_names:
-        print "* ",calculator_name_i
+        print("* ",calculator_name_i)
         rms[calculator_name_i] = {}
         for calculator_name_j in calculator_names:
-            print "\t ",calculator_name_j
+            print("\t ",calculator_name_j)
             rmsd_diff = rmsds[calculator_name_i] - rmsds[calculator_name_j]
             rms[calculator_name_i][calculator_name_j] = math.sqrt(numpy.sum(rmsd_diff**2))
     #---------------#

--- a/pyRMSD/benchmark/BenchmarkQCPDifferentInputSize.py
+++ b/pyRMSD/benchmark/BenchmarkQCPDifferentInputSize.py
@@ -3,6 +3,7 @@ Created on 22/02/2013
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import numpy
@@ -31,7 +32,7 @@ if __name__ == '__main__':
     coordsets = numpy.load("data/tmp_amber_long.npy")
     number_of_atoms = coordsets.shape[1]
     number_of_conformations = coordsets.shape[0]
-    print "Coordinates read (%d models, %d atoms)"%(number_of_conformations, number_of_atoms)
+    print("Coordinates read (%d models, %d atoms)"%(number_of_conformations, number_of_atoms))
     sys.stdout.flush()
     original_size = coordsets.shape[1]
     for times in range(10):
@@ -41,7 +42,7 @@ if __name__ == '__main__':
         rmsd = calculator.pairwiseRMSDMatrix()
         t2 = time.time()
         del rmsd
-        print "With CUDA and num. atoms %d it took: %fs"%(coordsets.shape[1],t2-t1)
+        print("With CUDA and num. atoms %d it took: %fs"%(coordsets.shape[1],t2-t1))
         sys.stdout.flush()
         coordsets = add_coordsets_copy(coordsets, original_size)
     #------------------
@@ -53,7 +54,7 @@ if __name__ == '__main__':
     number_of_atoms = coordsets.shape[1]
     number_of_conformations = coordsets.shape[0]
     original_size = coordsets.shape[1]
-    print "Coordinates read (%d models, %d atoms)"%(number_of_conformations, number_of_atoms)
+    print("Coordinates read (%d models, %d atoms)"%(number_of_conformations, number_of_atoms))
     sys.stdout.flush()
     for times in range(10):
         calculator = pyRMSD.RMSDCalculator.RMSDCalculator( calculatorType="QCP_OMP_CALCULATOR", fittingCoordsets=coordsets)
@@ -62,6 +63,6 @@ if __name__ == '__main__':
         rmsd = calculator.pairwiseRMSDMatrix()
         t2 = time.time()
         del rmsd
-        print "With OpenMP and num. atoms %d it took: %fs"%(coordsets.shape[1],t2-t1)
+        print("With OpenMP and num. atoms %d it took: %fs"%(coordsets.shape[1],t2-t1))
         sys.stdout.flush()
         coordsets = add_coordsets_copy(coordsets, original_size)

--- a/pyRMSD/benchmark/BenchmarkRMSDCalculators.py
+++ b/pyRMSD/benchmark/BenchmarkRMSDCalculators.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import collections
 import numpy.testing
 import pyRMSD.RMSDCalculator
@@ -16,19 +17,19 @@ if __name__ == '__main__':
     ######################
     # BENCHMARKING
     ######################
-    print "Loading file..."
+    print("Loading file...")
     t1 = time.time()
-    print "\tUncompressing..."
+    print("\tUncompressing...")
     open("tmp_amber_long.pdb","w").write(bz2.BZ2File("data/amber_long.pdb.tar.bz2").read())
-    print "\tLoading..."
+    print("\tLoading...")
     reader = Reader().readThisFile('tmp_amber_long.pdb').gettingOnlyCAs()
     coordsets = reader.read() 
     number_of_atoms = reader.numberOfAtoms
     number_of_conformations = reader.numberOfFrames
     os.system("rm tmp_amber_long.pdb")
-    print "\tDeleting temporary file"
+    print("\tDeleting temporary file")
     t2 = time.time()
-    print 'Loading took %0.3f s' % (t2-t1)
+    print('Loading took %0.3f s' % (t2-t1))
     
     #######################
     # CALCULATION
@@ -46,25 +47,25 @@ if __name__ == '__main__':
     golden = "QTRFIT_OMP_CALCULATOR"
     
     for CALC_TYPE in types:
-        print "Calculating RMSD with ", CALC_TYPE
+        print("Calculating RMSD with ", CALC_TYPE)
         t1 = time.time()
         rmsds[CALC_TYPE] = pyRMSD.RMSDCalculator.RMSDCalculator(calculatorType=CALC_TYPE, 
                                                                 fittingCoordsets=coordsets).pairwiseRMSDMatrix()
         t2 = time.time()
         times[CALC_TYPE] = t2-t1
-        print "\tRmsd array generated. ", len(rmsds[CALC_TYPE]), " elements."
-        print '\tMatrix generation with %s took %0.3fs' %(CALC_TYPE, t2-t1)
+        print("\tRmsd array generated. ", len(rmsds[CALC_TYPE]), " elements.")
+        print('\tMatrix generation with %s took %0.3fs' %(CALC_TYPE, t2-t1))
     
     ######################
     # VALIDATION
     #####################
     for CALC_TYPE in types:
         if CALC_TYPE != golden:
-            print "Comparing results (%s vs %s)..."%(golden, CALC_TYPE)
+            print("Comparing results (%s vs %s)..."%(golden, CALC_TYPE))
             t1 = time.time()
             numpy.testing.assert_array_almost_equal(rmsds[golden], rmsds[CALC_TYPE],precissions[CALC_TYPE])
             t2 = time.time()
-            print 'Comparison took %0.3fs' % (t2-t1)
+            print('Comparison took %0.3fs' % (t2-t1))
     
     for CALC_TYPE in types:
-        print CALC_TYPE,": ",times[CALC_TYPE]
+        print(CALC_TYPE,": ",times[CALC_TYPE])

--- a/pyRMSD/benchmark/BenchmarkSerial.py
+++ b/pyRMSD/benchmark/BenchmarkSerial.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import numpy
@@ -20,10 +21,10 @@ if __name__ == '__main__':
             ("amber_35k.pdb",3)]
     
     for pdb_file, tries in files:
-        print "Reading file ", "data/"+pdb_file,"...",
+        print("Reading file ", "data/"+pdb_file,"...", end=' ')
         sys.stdout.flush()
         coordsets = numpy.load("data/%s.npy"%pdb_file.split(".")[0])
-        print "OK"
+        print("OK")
         sys.stdout.flush()
         number_of_conformations = coordsets.shape[0]
         number_of_atoms = coordsets.shape[1]
@@ -36,7 +37,7 @@ if __name__ == '__main__':
             t2 = time.time()
             del rmsd
             times.append(t2-t1)
-        print "With Serial and ",pdb_file, " it took: ",numpy.mean(times),"[", numpy.std(times), "]"
+        print("With Serial and ",pdb_file, " it took: ",numpy.mean(times),"[", numpy.std(times), "]")
         sys.stdout.flush()
 
 #28

--- a/pyRMSD/benchmark/CUDABenchmarkPlot.py
+++ b/pyRMSD/benchmark/CUDABenchmarkPlot.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import matplotlib.pyplot
 from matplotlib.ticker import FormatStrFormatter
 import pylab
@@ -39,8 +40,8 @@ for i in range(len(tags)):
 		speedups[(first,second)] = file_times[first] /file_times[second]
 
 for key in speedups:
-	print key
-	print speedups[key]
+	print(key)
+	print(speedups[key])
 
 matplotlib.rc('xtick', labelsize=18) 
 matplotlib.rc('ytick', labelsize=18)

--- a/pyRMSD/benchmark/CompareAlgorithms.py
+++ b/pyRMSD/benchmark/CompareAlgorithms.py
@@ -3,6 +3,7 @@ Created on 14/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import pyRMSD.RMSDCalculator
 import time
 import numpy
@@ -10,10 +11,10 @@ import sys
 
 if __name__ == '__main__':
 
-	print "Reading file data/amber_30k.npy ...",
+	print("Reading file data/amber_30k.npy ...", end=' ')
 	sys.stdout.flush()
 	coordsets = numpy.load("data/amber_30k.npy")
-	print "OK"
+	print("OK")
 	number_of_conformations = coordsets.shape[0]
 	number_of_atoms = coordsets.shape[1]
 
@@ -27,7 +28,7 @@ if __name__ == '__main__':
 			t2 = time.time()
 			del rmsd
 			times.append(t2-t1)
-		print "Using ",calculator_type, " without modifying coordinates it took: ",numpy.mean(times),"[", numpy.std(times), "]"
+		print("Using ",calculator_type, " without modifying coordinates it took: ",numpy.mean(times),"[", numpy.std(times), "]")
 	
 		times = []
 		for i in range(10):
@@ -37,7 +38,7 @@ if __name__ == '__main__':
 			t2 = time.time()
 			del rmsd
 			times.append(t2-t1)
-		print "Using ",calculator_type, " and modifying coordinates it took: ",numpy.mean(times),"[", numpy.std(times), "]"
+		print("Using ",calculator_type, " and modifying coordinates it took: ",numpy.mean(times),"[", numpy.std(times), "]")
 		times = []
 		for i in range(10):
 			calculator = pyRMSD.RMSDCalculator.RMSDCalculator(coordsets, calculator_type, modifyCoordinates=True)
@@ -46,7 +47,7 @@ if __name__ == '__main__':
 			t2 = time.time()
 			del rmsd
 			times.append(t2-t1)
-		print "Iterative superposition using",calculator_type, " and modifying coordinates it took: ",numpy.mean(times),"[", numpy.std(times), "]"
+		print("Iterative superposition using",calculator_type, " and modifying coordinates it took: ",numpy.mean(times),"[", numpy.std(times), "]")
 		for i in range(10):
 			calculator = pyRMSD.RMSDCalculator.RMSDCalculator(coordsets, calculator_type, modifyCoordinates=True)
 			t1 = time.time()
@@ -54,7 +55,7 @@ if __name__ == '__main__':
 			t2 = time.time()
 			del rmsd
 			times.append(t2-t1)
-		print "Matrix using",calculator_type, " took", numpy.mean(times),"[", numpy.std(times), "]"
+		print("Matrix using",calculator_type, " took", numpy.mean(times),"[", numpy.std(times), "]")
 
 
 

--- a/pyRMSD/benchmark/DrawBenchmarkGraph.py
+++ b/pyRMSD/benchmark/DrawBenchmarkGraph.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import matplotlib.pyplot
 from matplotlib.ticker import FormatStrFormatter
 import pylab
@@ -27,8 +28,8 @@ for i in range(len(tags)):
         speedups[(first,second)] = file_times[first] /file_times[second]
 
 for key in speedups:
-    print key
-    print speedups[key]
+    print(key)
+    print(speedups[key])
 
 matplotlib.rc('xtick', labelsize=18) 
 matplotlib.rc('ytick', labelsize=18)

--- a/pyRMSD/benchmark/alias/condensedMatrix.py
+++ b/pyRMSD/benchmark/alias/condensedMatrix.py
@@ -72,7 +72,7 @@ class CondensedMatrix(object):
                 else:
                     real_pos = self.__condensedsubscript(index[1],index[0]-1)
                 return self.contents[real_pos]
-        except Exception,msg:
+        except Exception as msg:
             print ("[Error in CondensedDistanceMatrix::__getitem__]",msg)
             exit(0)
 
@@ -86,7 +86,7 @@ class CondensedMatrix(object):
                 else:
                     real_pos = self.__condensedsubscript(index[1],index[0]-1)
             self.contents[real_pos] = item
-        except Exception,msg:
+        except Exception as msg:
             print ("[Error in CondensedDistanceMatrix::__setitem__]",msg)
             exit(0)
 

--- a/pyRMSD/matrixHandler.py
+++ b/pyRMSD/matrixHandler.py
@@ -3,6 +3,7 @@ Created on 19/09/2012
 
 @author: victor
 """
+from __future__ import print_function
 import json
 import numpy
 import os.path
@@ -38,11 +39,11 @@ class MatrixHandler(object):
 
         @return: A condensed matrix with the pairwise RMSD matrix.
         """
-        print "Calculating matrix ..."
+        print("Calculating matrix ...")
         rmsd = pyRMSD.RMSDCalculator.RMSDCalculator(calculator, pdb_coordsets).pairwiseRMSDMatrix()
         self.distance_matrix = CondensedMatrix(rmsd)
         MatrixHandler.save_statistics(self.statistics_folder,self.distance_matrix)
-        print " Done"
+        print(" Done")
         return self.distance_matrix
 
     def saveMatrix(self, matrix_file_without_extension):
@@ -52,9 +53,9 @@ class MatrixHandler(object):
         @param matrix_file_without_extension: Is the matrix file name without any
         extension ('.bin' will be added).
         """
-        print "Writing matrix data (in "+matrix_file_without_extension+".bin) ...",
+        print("Writing matrix data (in "+matrix_file_without_extension+".bin) ...", end=' ')
         MatrixHandler.save_matrix(matrix_file_without_extension, self.distance_matrix)
-        print " Done"
+        print(" Done")
 
     def loadMatrix(self, matrix_file_without_extension):
         """
@@ -63,9 +64,9 @@ class MatrixHandler(object):
         @param matrix_file_without_extension: Is the matrix file name without any
         extension ('.bin' will be added).
         """
-        print "Loading matrix data from "+matrix_file_without_extension+".bin ...",
+        print("Loading matrix data from "+matrix_file_without_extension+".bin ...", end=' ')
         self.distance_matrix = MatrixHandler.load_matrix(matrix_file_without_extension)
-        print " Done"
+        print(" Done")
 
     @classmethod
     def save_matrix(cls, matrix_file_without_extension, distance_matrix):
@@ -101,7 +102,7 @@ class MatrixHandler(object):
         @param distance_matrix: The distance matrix from which the statistics are calculated.
         """
         if statistics_folder is not None:
-            print "Calculating statistics ..."
+            print("Calculating statistics ...")
             stats_dic = {}
             stats_dic["Minimum"] =  distance_matrix.calculateMin()
             stats_dic["Maximum"] =  distance_matrix.calculateMax()

--- a/pyRMSD/symmTools.py
+++ b/pyRMSD/symmTools.py
@@ -3,6 +3,7 @@ Created on 29/07/2013
 
 @author: victor
 """
+from __future__ import print_function
 
 
 def symm_groups_validation( symm_groups):
@@ -55,9 +56,9 @@ def symm_permutations(groups):
         yield []
         
 def swap_atoms(coordset_reference, atom_i, atom_j):
-    #print "PRIMA", coordset_reference
+    #print("PRIMA", coordset_reference)
     coordset_reference[[atom_i,atom_j]] =  coordset_reference[[atom_j,atom_i]]
-    #print "DOPO", coordset_reference
+    #print("DOPO", coordset_reference)
     
 def min_rmsd_of_rmsds_list(rmsds_list):
     return (rmsds_list.T).min(1)

--- a/pyRMSD/test/testMatrixStatistics.py
+++ b/pyRMSD/test/testMatrixStatistics.py
@@ -3,16 +3,21 @@ Created on 15/11/2012
 
 @author: victor
 """
+from __future__ import division
 import unittest
 from pyRMSD.condensedMatrix import CondensedMatrix
 import random 
 import numpy
+import sys
+
+if sys.version_info[0] >= 3:
+    xrange = range
 
 class testMatrixStatistics(unittest.TestCase):
     
     def setUp(self):
         random.seed(12345)
-        num_elems = 50*49/2;
+        num_elems = 50*49//2;
         self.contents = random.sample(xrange(num_elems+1),num_elems)
         self.condensedMatrix = CondensedMatrix(self.contents)
         

--- a/pyRMSD/test/testRMSDCalculators.py
+++ b/pyRMSD/test/testRMSDCalculators.py
@@ -3,6 +3,7 @@ Created on 16/11/2012
 
 @author: victor
 """
+from __future__ import print_function
 import unittest
 import pyRMSD.RMSDCalculator
 import numpy
@@ -28,7 +29,7 @@ class TestRMSDCalculators(unittest.TestCase):
                                        0.93694602,0.76944618,0.82288799,0.91196003,0.75938856,0.68278426,
                                        0.76302383]
     def setUp(self):
-#         print "In method", self._testMethodName
+#         print("In method", self._testMethodName)
         # Each test gets a fresh coordinates set, as they will modify the coordinates
         # QCP is specially sensitive to variations in input coordinates and results can vary
         self.coordsets_mini =  numpy.load("data/coordsets_mini.npy")
@@ -280,7 +281,7 @@ class TestRMSDCalculators(unittest.TestCase):
                                                                              ])
         
         rmsds = calculator.pairwiseRMSDMatrix()
-        print rmsds
+        print(rmsds)
         
         
     # ------------------------------------------------------

--- a/pyRMSD/utils/proteinReading.py
+++ b/pyRMSD/utils/proteinReading.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy
 import pyRMSD.pdbReader
 
@@ -80,12 +81,12 @@ class Reader(object):
             if not self.__checkAndUpdateNumberOfAtoms(atoms_in_this_trajectory,path):
                 return None
             
-            if verbose: print "PDB parsed (",path,")"
+            if verbose: print("PDB parsed (",path,")")
             
             coordinates = numpy.append(coordinates, coordsets, axis=0)
             del coordsets
             del reader
-        print coordinates.shape, (self.numberOfFrames, self.numberOfAtoms, 3)
+        print(coordinates.shape, (self.numberOfFrames, self.numberOfAtoms, 3))
         coordinates.shape = (self.numberOfFrames, self.numberOfAtoms, 3)
         return coordinates
         
@@ -102,7 +103,7 @@ class Reader(object):
         """
         if( self.numberOfAtoms != None):
             if self.numberOfAtoms != atoms_in_this_trajectory:
-                print "[Error :: Reader.read] The number of atoms of ", path, " is different from the number of atoms of the first trajectory."
+                print("[Error :: Reader.read] The number of atoms of ", path, " is different from the number of atoms of the first trajectory.")
                 return False
             else:
                 return True

--- a/src/pdbreaderlite/PDBReaderObject.cpp
+++ b/src/pdbreaderlite/PDBReaderObject.cpp
@@ -100,8 +100,12 @@ static PyMethodDef pdbreader_methods[] = {
 };
 
 static PyTypeObject pdbreaderType = {
+#if PY_VERSION_HEX >= 0x03000000
+    PyVarObject_HEAD_INIT(NULL, 0)
+#else
     PyObject_HEAD_INIT(NULL)
     0,                         						/*ob_size*/
+#endif
     "PDBReader.Reader",      	/*tp_name*/
     sizeof(pdbreader), 	/*tp_basicsize*/
     0,                         /*tp_itemsize*/
@@ -146,18 +150,43 @@ static PyTypeObject pdbreaderType = {
 #endif
 
 
+#if PY_MAJOR_VERSION >= 3
+#define MODULE_INIT_ERROR NULL
+PyMODINIT_FUNC PyInit_pdbReader(void){
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "pdbReader",           /* m_name */
+        "Simple pdb reading",  /* m_doc */
+        -1,                    /* m_size */
+        NULL,                  /* m_methods */
+        NULL,                  /* m_reload */
+        NULL,                  /* m_traverse */
+        NULL,                  /* m_clear */
+        NULL,                  /* m_free */
+    };
+#else
+#define MODULE_INIT_ERROR
 PyMODINIT_FUNC initpdbReader(void){
+#endif
+
     PyObject* module;
 
     if (PyType_Ready(&pdbreaderType) < 0)
-        return;
+        return MODULE_INIT_ERROR;
 
+#if PY_MAJOR_VERSION >= 3
+    module = PyModule_Create(&moduledef);
+#else
     module = Py_InitModule3("pdbReader", NULL,"Simple pdb reading");
+#endif
     if (module == NULL)
-          return;
+          return MODULE_INIT_ERROR;
 
     Py_INCREF(&pdbreaderType);
     PyModule_AddObject(module, "PDBReader", (PyObject*) &pdbreaderType);
 
     import_array();
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
 }

--- a/src/python/pyRMSD.cpp
+++ b/src/python/pyRMSD.cpp
@@ -5,6 +5,11 @@
 #include "../calculators/factory/RMSDCalculatorFactory.h"
 #include "../calculators/RMSDCalculator.h"
 #include "../calculators/symmGroups.h"
+
+#if PY_VERSION_HEX >= 0x03000000
+#define PyInt_AsLong(x) PyLong_AsLong(x)
+#endif
+
 using namespace std;
 
 struct Params{
@@ -279,8 +284,32 @@ static PyMethodDef pyRMSDMethods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
+PyMODINIT_FUNC PyInit_calculators(void){
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "calculators",         /* m_name */
+        "calculators",         /* m_doc */
+        -1,                    /* m_size */
+        pyRMSDMethods,         /* m_methods */
+        NULL,                  /* m_reload */
+        NULL,                  /* m_traverse */
+        NULL,                  /* m_clear */
+        NULL,                  /* m_free */
+    };
+    PyObject *module;
+#else
 PyMODINIT_FUNC initcalculators(void){
-    (void) Py_InitModule("calculators", pyRMSDMethods);
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    module = PyModule_Create(&moduledef);
+#else
+        (void) Py_InitModule("calculators", pyRMSDMethods);
+#endif
 
     import_array();
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
 }


### PR DESCRIPTION
This should add full Python 3 support by making a number of simple modifications so that the code builds and runs with both Python 2 and Python 3:

 - Use print function rather than print statement;
 - Use Python 3 C API protected with preprocessor macros; 
 - Replace `except x,y` with `except x as y`;
 - Use `range` in Python 3 rather than `xrange`.