### PR TITLE
Fix off-by-one error

### DIFF
--- a/src/calculators/RMSDCalculator.cpp
+++ b/src/calculators/RMSDCalculator.cpp
@@ -114,7 +114,7 @@ void RMSDCalculator::calculate_rmsd_condensed_matrix_with_fitting_coordinates(ve
 	
 	this->kernelFunctions->matrixInit(rmsdData);
 
-	for(int reference_index = 0; reference_index < this->rmsdData->numberOfConformations; ++reference_index){
+	for(int reference_index = 0; reference_index < this->rmsdData->numberOfConformations - 1; ++reference_index){
 			int offset = reference_index*(this->rmsdData->numberOfConformations-1)- (((reference_index-1)*reference_index)/2) ;
 			double* reference_conformation = this->rmsdData->getFittingConformationAt(reference_index);
 			this->kernelFunctions->matrixOneVsFollowingFitEqualCalc(


### PR DESCRIPTION
When trying to calculate the RMSDs involving the last conformation, an offset one past the end of the rmsd vector was being used. This is probably OK as it is never written to (there are zero RMSDs to calculate as it is a triangular matrix) but nevertheless is both slightly inefficient and triggers a glibc assertion failure.